### PR TITLE
feat(token): Deref item to token automatically

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,6 +586,19 @@ this.y = 0;
             assert_eq!((i, p.to_string()), (i, q))
         }
     }
+
+    #[test]
+    fn item_deref_to_token() {
+        let js = "function ( ) { return ; }";
+        let mut s = Scanner::new(js);
+        let i: Item = s.next().unwrap();
+
+        // explicit reference to token
+        assert!(i.token.is_keyword());
+        // implitic deref to token
+        assert!(i.is_keyword());
+    }
+
     #[test]
     fn spans() {
         let js = include_str!("../node_modules/esprima/dist/esprima.js");

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use combine::{
     choice, eof,
     error::ParseError,
@@ -29,6 +31,14 @@ impl Item {
         Item { token, span }
     }
 }
+
+impl Deref for Item {
+    type Target = Token;
+    fn deref<'a>(&'a self) -> &'a Self::Target {
+        &self.token
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 /// A location in the original source text
 pub struct Span {


### PR DESCRIPTION
Implements the [Deref](https://doc.rust-lang.org/std/ops/trait.Deref.html) trait for `Item`. This will automatically dereference to `Token` when calling a `Token` specific method such as `is_boolean`.

The only common namespace between `Item`, `Span` and `Token` appears to be `::new`, which should therefore always be called explicitly.

Closes #13 