### PR TITLE
Next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ress"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Robert Masen <r@robertmasen.pizza>"]
 description = "A sanner/tokenizer for JS files"
 keywords = ["JavaScript", "parsing", "JS", "ES", "ECMA"]

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -3,7 +3,7 @@ use combine::{
     error::ParseError,
     optional,
     parser::{char::string, repeat::take_until},
-    try, Parser, Stream,
+    attempt, Parser, Stream,
 };
 use strings;
 use tokens::Token;
@@ -79,9 +79,9 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(multi_comment()),
-        try(single_comment()),
-        try(html_comment()),
+        attempt(multi_comment()),
+        attempt(single_comment()),
+        attempt(html_comment()),
     )).map(Token::Comment)
 }
 
@@ -93,8 +93,8 @@ where
     (
         string("//"),
         take_until(choice((
-            try(strings::line_terminator_sequence()),
-            try(eof().map(|_| String::new())),
+            attempt(strings::line_terminator_sequence()),
+            attempt(eof().map(|_| String::new())),
         ))),
     )
         .map(|(_, content): (_, String)| Comment::new_single_line(&content))
@@ -107,7 +107,7 @@ where
 {
     (
         multi_line_comment_start(),
-        take_until(try(string("*/"))),
+        take_until(attempt(string("*/"))),
         multi_line_comment_end(),
     )
         .map(|(_s, c, _e): (String, String, String)| Comment::new_multi_line(&c))
@@ -136,9 +136,9 @@ where
 {
     (
         string("<!--"),
-        take_until(try(string("-->"))),
+        take_until(attempt(string("-->"))),
         string("-->"),
-        optional(take_until(try(strings::line_terminator_sequence()))),
+        optional(take_until(attempt(strings::line_terminator_sequence()))),
     )
         .map(|(_, content, _, tail): (_, String, _, Option<String>)| {
             Comment::new_html(&content, tail)

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1,5 +1,5 @@
 use combine::{
-    choice, error::ParseError, not_followed_by, parser::char::string, try, Parser, Stream,
+    choice, error::ParseError, not_followed_by, parser::char::string, attempt, Parser, Stream,
 };
 use tokens::{raw_ident_part, Token};
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -316,9 +316,9 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(future_reserved()),
-        try(strict_mode_reserved()),
-        try(reserved()),
+        attempt(future_reserved()),
+        attempt(strict_mode_reserved()),
+        attempt(reserved()),
     )).skip(not_followed_by(raw_ident_part()))
     .map(|t| t)
 }
@@ -356,35 +356,35 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice([
-        try(string("await")),
-        try(string("break")),
-        try(string("case")),
-        try(string("catch")),
-        try(string("class")),
-        try(string("const")),
-        try(string("continue")),
-        try(string("debugger")),
-        try(string("default")),
-        try(string("delete")),
-        try(string("do")),
-        try(string("else")),
-        try(string("finally")),
-        try(string("for")),
-        try(string("function")),
-        try(string("if")),
-        try(string("instanceof")),
-        try(string("in")),
-        try(string("new")),
-        try(string("return")),
-        try(string("switch")),
-        try(string("this")),
-        try(string("throw")),
-        try(string("try")),
-        try(string("typeof")),
-        try(string("var")),
-        try(string("void")),
-        try(string("while")),
-        try(string("with")),
+        attempt(string("await")),
+        attempt(string("break")),
+        attempt(string("case")),
+        attempt(string("catch")),
+        attempt(string("class")),
+        attempt(string("const")),
+        attempt(string("continue")),
+        attempt(string("debugger")),
+        attempt(string("default")),
+        attempt(string("delete")),
+        attempt(string("do")),
+        attempt(string("else")),
+        attempt(string("finally")),
+        attempt(string("for")),
+        attempt(string("function")),
+        attempt(string("if")),
+        attempt(string("instanceof")),
+        attempt(string("in")),
+        attempt(string("new")),
+        attempt(string("return")),
+        attempt(string("switch")),
+        attempt(string("this")),
+        attempt(string("throw")),
+        attempt(string("try")),
+        attempt(string("typeof")),
+        attempt(string("var")),
+        attempt(string("void")),
+        attempt(string("while")),
+        attempt(string("with")),
     ]).map(|t| Token::Keyword(Keyword::from(t.to_owned())))
 }
 /// Generate a parser that will return an instance of Token::Keyword when one of the
@@ -401,10 +401,10 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(string("export")),
-        try(string("import")),
-        try(string("super")),
-        try(string("enum")),
+        attempt(string("export")),
+        attempt(string("import")),
+        attempt(string("super")),
+        attempt(string("enum")),
     )).map(|t| Token::Keyword(Keyword::from(t)))
 }
 
@@ -427,15 +427,15 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(string("implements")),
-        try(string("interface")),
-        try(string("package")),
-        try(string("private")),
-        try(string("protected")),
-        try(string("public")),
-        try(string("static")),
-        try(string("yield")),
-        try(string("let")),
+        attempt(string("implements")),
+        attempt(string("interface")),
+        attempt(string("package")),
+        attempt(string("private")),
+        attempt(string("protected")),
+        attempt(string("public")),
+        attempt(string("static")),
+        attempt(string("yield")),
+        attempt(string("let")),
     )).map(|t| Token::Keyword(Keyword::from(t)))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl Scanner {
                 break;
             }
         }
-        debug!(target: "ress", "skipped {} bytes worth of comments", new_cursor - self.cursor);
+        debug!(target: "ress", "skipped {} bytes worth of comments", new_cursor.saturating_sub(self.cursor));
         self.cursor = new_cursor;
     }
     /// Get a copy of the scanner's current state

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,12 +148,7 @@ impl Scanner {
             return None;
         };
         let prev_cursor = self.cursor;
-        let result = if self.template > 0 && self.template < self.replacement {
-            debug!(target: "ress", "parsing template continuation");
-            strings::template_continuation().parse(&self.stream[self.cursor..])
-        } else {
-            tokens::token().parse(&self.stream[self.cursor..])
-        };
+        let result = tokens::token().parse(&self.stream[self.cursor..]);
         match result {
             Ok(pair) => {
                 if pair.0.matches_punct(Punct::ForwardSlash) && self.is_regex_start() {
@@ -165,11 +160,9 @@ impl Scanner {
                             if advance_cursor {
                                 self.spans.push(span.clone());
                                 self.cursor = self.stream.len()
-                                    - regex_pair.1.trim_left_matches(whitespace).len();
+                                    - regex_pair.1.trim_left_matches(whitespace_or_line_term).len();
                                 let whitespace = &self.stream[prev_cursor..self.cursor];
-                                self.pending_new_line = whitespace.chars().any(|c| {
-                                    c == '\n' || c == '\r' || c == '\u{2028}' || c == '\u{2029}'
-                                });
+                                self.pending_new_line = whitespace.chars().any(|c| is_line_term(c));
                             }
                             debug!(target: "ress", "{}: {:?}", if advance_cursor { "next regex item" } else {"look ahead"}, regex_pair.0);
                             Some(Item::new(regex_pair.0, span))
@@ -180,13 +173,11 @@ impl Scanner {
                         ),
                     }
                 } else if self.template > 0
-                    && self.replacement == self.template
                     && pair.0.matches_punct(Punct::CloseBrace)
                 {
                     match strings::template_continuation().parse(pair.1) {
                         Ok(pair) => {
                             if pair.0.is_template_tail() && advance_cursor {
-                                self.replacement = self.replacement.saturating_sub(1);
                                 self.template = self.template.saturating_sub(1);
                             }
                             let full_len = self.stream.len();
@@ -195,11 +186,9 @@ impl Scanner {
                             if advance_cursor {
                                 self.spans.push(span.clone());
                                 self.cursor =
-                                    self.stream.len() - pair.1.trim_left_matches(whitespace).len();
+                                    self.stream.len() - pair.1.trim_left_matches(whitespace_or_line_term).len();
                                 let whitespace = &self.stream[prev_cursor..self.cursor];
-                                self.pending_new_line = whitespace.chars().any(|c| {
-                                    c == '\n' || c == '\r' || c == '\u{2028}' || c == '\u{2029}'
-                                });
+                                self.pending_new_line = whitespace.chars().any(is_line_term);
                             }
                             debug!(target: "ress", "{}: {:?}", if advance_cursor { "next template item" } else {"look ahead"}, pair.0);
                             Some(Item::new(pair.0, span))
@@ -216,9 +205,8 @@ impl Scanner {
                     if pair.0.is_eof() && advance_cursor {
                         self.eof = true;
                     }
-                    if pair.0.is_template_head() && advance_cursor {
+                    if pair.0.is_template_head() && advance_cursor && !pair.0.is_template_tail() {
                         self.template += 1;
-                        self.replacement += 1;
                     }
                     let full_len = self.stream.len();
                     let span_end = full_len - pair.1.len();
@@ -226,11 +214,11 @@ impl Scanner {
                     if advance_cursor {
                         self.spans.push(span.clone());
                         self.cursor =
-                            self.stream.len() - pair.1.trim_left_matches(whitespace).len();
+                            self.stream.len() - pair.1.trim_left_matches(whitespace_or_line_term).len();
                         let whitespace = &self.stream[prev_cursor..self.cursor];
                         self.pending_new_line = whitespace
                             .chars()
-                            .any(|c| c == '\n' || c == '\r' || c == '\u{2028}' || c == '\u{2029}');
+                            .any(|c| is_line_term(c));
                     }
                     debug!(target: "ress", "{}: {:?}", if advance_cursor { "next item" } else {"look ahead"}, pair.0);
                     Some(Item::new(pair.0, span))
@@ -386,6 +374,10 @@ impl Scanner {
             Some(self.stream[span.start..span.end].to_string())
         }
     }
+}
+
+fn whitespace_or_line_term(c: char) -> bool {
+    whitespace(c) || is_line_term(c)
 }
 
 fn whitespace(c: char) -> bool {

--- a/src/numeric.rs
+++ b/src/numeric.rs
@@ -3,7 +3,7 @@ use combine::{
     error::ParseError,
     many, many1, optional,
     parser::char::{char as c_char, digit, hex_digit, oct_digit},
-    try, Parser, Stream,
+    attempt, Parser, Stream,
 };
 
 use tokens::Token;
@@ -75,10 +75,10 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(bin_literal()),
-        try(octal_literal()),
-        try(hex_literal()),
-        try(decimal_literal()),
+        attempt(bin_literal()),
+        attempt(octal_literal()),
+        attempt(hex_literal()),
+        attempt(decimal_literal()),
     )).map(super::Token::Numeric)
 }
 
@@ -87,7 +87,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    choice((try(full_decimal_literal()), try(no_leading_decimal()))).map(|t| t)
+    choice((attempt(full_decimal_literal()), attempt(no_leading_decimal()))).map(|t| t)
 }
 
 fn full_decimal_literal<I>() -> impl Parser<Input = I, Output = Number>

--- a/src/punct.rs
+++ b/src/punct.rs
@@ -3,7 +3,7 @@ use combine::{
     error::ParseError,
     not_followed_by,
     parser::char::{char as c_char, string},
-    try, Parser, Stream,
+    attempt, Parser, Stream,
 };
 use tokens::Token;
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -191,7 +191,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    choice((try(multi_punct()), try(single_punct()))).map(|t: String| Token::Punct(Punct::from(t)))
+    choice((attempt(multi_punct()), attempt(single_punct()))).map(|t: String| Token::Punct(Punct::from(t)))
 }
 
 fn single_punct<I>() -> impl Parser<Input = I, Output = String>
@@ -199,7 +199,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    choice((try(normal_punct()), try(div_punct()))).map(|c| c.to_string())
+    choice((attempt(normal_punct()), attempt(div_punct()))).map(|c| c.to_string())
 }
 
 fn normal_punct<I>() -> impl Parser<Input = I, Output = char>
@@ -207,7 +207,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    choice((try(c_char('}')), try(normal_punct_not_close_brace()))).map(|c: char| c)
+    choice((attempt(c_char('}')), attempt(normal_punct_not_close_brace()))).map(|c: char| c)
 }
 
 fn normal_punct_not_close_brace<I>() -> impl Parser<Input = I, Output = char>
@@ -216,28 +216,28 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice([
-        try(c_char('{')),
-        try(c_char('(')),
-        try(c_char(')')),
-        try(c_char('.')),
-        try(c_char(';')),
-        try(c_char(',')),
-        try(c_char('[')),
-        try(c_char(']')),
-        try(c_char(':')),
-        try(c_char('?')),
-        try(c_char('~')),
-        try(c_char('>')),
-        try(c_char('<')),
-        try(c_char('=')),
-        try(c_char('!')),
-        try(c_char('+')),
-        try(c_char('-')),
-        try(c_char('*')),
-        try(c_char('%')),
-        try(c_char('&')),
-        try(c_char('|')),
-        try(c_char('^')),
+        attempt(c_char('{')),
+        attempt(c_char('(')),
+        attempt(c_char(')')),
+        attempt(c_char('.')),
+        attempt(c_char(';')),
+        attempt(c_char(',')),
+        attempt(c_char('[')),
+        attempt(c_char(']')),
+        attempt(c_char(':')),
+        attempt(c_char('?')),
+        attempt(c_char('~')),
+        attempt(c_char('>')),
+        attempt(c_char('<')),
+        attempt(c_char('=')),
+        attempt(c_char('!')),
+        attempt(c_char('+')),
+        attempt(c_char('-')),
+        attempt(c_char('*')),
+        attempt(c_char('%')),
+        attempt(c_char('&')),
+        attempt(c_char('|')),
+        attempt(c_char('^')),
     ]).map(|c: char| c)
 }
 
@@ -256,36 +256,36 @@ where
 {
     choice([
         //4 char
-        try(string(">>>=")),
+        attempt(string(">>>=")),
         //3 char
-        try(string("...")),
-        try(string("===")),
-        try(string("!==")),
-        try(string(">>>")),
-        try(string("<<=")),
-        try(string(">>=")),
-        try(string("**=")),
+        attempt(string("...")),
+        attempt(string("===")),
+        attempt(string("!==")),
+        attempt(string(">>>")),
+        attempt(string("<<=")),
+        attempt(string(">>=")),
+        attempt(string("**=")),
         //2 char
-        try(string("&&")),
-        try(string("||")),
-        try(string("==")),
-        try(string("!=")),
-        try(string("+=")),
-        try(string("-=")),
-        try(string("*=")),
-        try(string("/=")),
-        try(string("++")),
-        try(string("--")),
-        try(string("<<")),
-        try(string(">>")),
-        try(string("&=")),
-        try(string("|=")),
-        try(string("^=")),
-        try(string("%=")),
-        try(string("<=")),
-        try(string(">=")),
-        try(string("=>")),
-        try(string("**")),
+        attempt(string("&&")),
+        attempt(string("||")),
+        attempt(string("==")),
+        attempt(string("!=")),
+        attempt(string("+=")),
+        attempt(string("-=")),
+        attempt(string("*=")),
+        attempt(string("/=")),
+        attempt(string("++")),
+        attempt(string("--")),
+        attempt(string("<<")),
+        attempt(string(">>")),
+        attempt(string("&=")),
+        attempt(string("|=")),
+        attempt(string("^=")),
+        attempt(string("%=")),
+        attempt(string("<=")),
+        attempt(string(">=")),
+        attempt(string("=>")),
+        attempt(string("**")),
     ]).map(|t| t.to_string())
 }
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -6,7 +6,7 @@ use combine::{
         char::{char as c_char, spaces, string},
         item::satisfy,
     },
-    try, Parser, Stream,
+    attempt, Parser, Stream,
 };
 
 use super::{is_line_term, is_source_char};
@@ -127,10 +127,10 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(string(r#"\'"#).map(|s: &str| s.to_string())),
-        try(string(r#"\\"#).map(|s: &str| s.to_string())),
-        try(string_continuation()),
-        try(satisfy(|c: char| c != '\'' && !is_line_term(c)).map(|c: char| c.to_string())),
+        attempt(string(r#"\'"#).map(|s: &str| s.to_string())),
+        attempt(string(r#"\\"#).map(|s: &str| s.to_string())),
+        attempt(string_continuation()),
+        attempt(satisfy(|c: char| c != '\'' && !is_line_term(c)).map(|c: char| c.to_string())),
     )).map(|s: String| s)
 }
 
@@ -158,10 +158,10 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(string(r#"\""#).map(|s: &str| s.to_string())),
-        try(string(r#"\\"#).map(|s: &str| s.to_string())),
-        try(string_continuation()),
-        try(satisfy(|c: char| c != '"' && !is_line_term(c)).map(|c: char| c.to_string())),
+        attempt(string(r#"\""#).map(|s: &str| s.to_string())),
+        attempt(string(r#"\\"#).map(|s: &str| s.to_string())),
+        attempt(string_continuation()),
+        attempt(satisfy(|c: char| c != '"' && !is_line_term(c)).map(|c: char| c.to_string())),
     )).map(|c: String| c)
 }
 
@@ -179,8 +179,8 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(string("\r\n").map(|s: &str| s.to_string())),
-        try(line_terminator().map(|c: char| c.to_string())),
+        attempt(string("\r\n").map(|s: &str| s.to_string())),
+        attempt(line_terminator().map(|c: char| c.to_string())),
     )).map(|s: String| s)
 }
 
@@ -189,7 +189,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    choice((try(no_sub_template()), try(template_head()))).map(Token::Template)
+    choice((attempt(no_sub_template()), attempt(template_head()))).map(Token::Template)
 }
 
 pub(crate) fn template_continuation<I>() -> impl Parser<Input = I, Output = Token>
@@ -197,7 +197,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    choice((try(template_middle()), try(template_tail()))).map(Token::Template)
+    choice((attempt(template_middle()), attempt(template_tail()))).map(Token::Template)
 }
 
 fn no_sub_template<I>() -> impl Parser<Input = I, Output = Template>
@@ -229,7 +229,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    (try(many(template_char())), c_char('`')).map(|(s, _): (String, _)| Template::Tail(s))
+    (attempt(many(template_char())), c_char('`')).map(|(s, _): (String, _)| Template::Tail(s))
 }
 
 fn template_char<I>() -> impl Parser<Input = I, Output = String>
@@ -238,13 +238,13 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(c_char('$')
+        attempt(c_char('$')
             .skip(not_followed_by(c_char('{')))
             .map(|c: char| c.to_string())),
-        try(string(r#"\${"#).map(|s: &str| s.to_string())),
-        try(string(r#"\`"#).map(|s: &str| s.to_string())),
-        try(string(r#"\"#).map(|s: &str| s.to_string())),
-        try(satisfy(|c: char| is_source_char(c) && c != '`' && c != '$')
+        attempt(string(r#"\${"#).map(|s: &str| s.to_string())),
+        attempt(string(r#"\`"#).map(|s: &str| s.to_string())),
+        attempt(string(r#"\"#).map(|s: &str| s.to_string())),
+        attempt(satisfy(|c: char| is_source_char(c) && c != '`' && c != '$')
             .map(|c: char| c.to_string())),
     )).map(|s: String| s)
 }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -92,6 +92,12 @@ impl Template {
             _ => false,
         }
     }
+    pub fn is_no_sub(&self) -> bool {
+        match self {
+            Template::NoSub(_) => true,
+            _ => false,
+        }
+    }
 }
 
 impl ToString for Template {
@@ -110,7 +116,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    choice((try(single_quote()), try(double_quote()))).map(Token::String)
+    choice((attempt(single_quote()), attempt(double_quote()))).map(Token::String)
 }
 
 fn single_quote<I>() -> impl Parser<Input = I, Output = StringLit>

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -467,11 +467,20 @@ impl Token {
         }
     }
     pub fn is_template(&self) -> bool {
-        self.is_template_head() || self.is_template_middle() || self.is_template_tail()
+        match self {
+            Token::Template(_) => true,
+            _ => false,
+        }
+    }
+    pub fn is_template_no_sub(&self) -> bool {
+        match self {
+            Token::Template(ref s) => s.is_no_sub(),
+            _ => false
+        }
     }
     pub fn is_template_head(&self) -> bool {
         match self {
-            Token::Template(ref s) => s.is_head(),
+            Token::Template(ref s) => s.is_head() || s.is_no_sub(),
             _ => false,
         }
     }
@@ -483,7 +492,7 @@ impl Token {
     }
     pub fn is_template_tail(&self) -> bool {
         match self {
-            Token::Template(ref s) => s.is_tail(),
+            Token::Template(ref s) => s.is_tail() || s.is_no_sub(),
             _ => false,
         }
     }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -5,7 +5,7 @@ use combine::{
     error::ParseError,
     many, not_followed_by,
     parser::char::{char as c_char, string},
-    try, Parser, Stream,
+    attempt, Parser, Stream,
 };
 
 use comments;
@@ -630,13 +630,13 @@ where
     choice((
         comments::comment(),
         boolean_literal(),
-        try(keywords::literal()),
-        try(ident()),
-        try(null_literal()),
-        try(numeric::literal()),
-        try(strings::literal()),
-        try(punct::punctuation()),
-        try(strings::template_start()),
+        attempt(keywords::literal()),
+        attempt(ident()),
+        attempt(null_literal()),
+        attempt(numeric::literal()),
+        attempt(strings::literal()),
+        attempt(punct::punctuation()),
+        attempt(strings::template_start()),
     )).map(|t| t)
 }
 
@@ -645,7 +645,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    choice((try(true_literal()), try(false_literal())))
+    choice((attempt(true_literal()), attempt(false_literal())))
         .map(|t: String| Token::Boolean(BooleanLiteral::from(t)))
 }
 
@@ -716,10 +716,10 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(unicode::id_start().map(|c: char| c.to_string())),
-        try(c_char('$').map(|c: char| c.to_string())),
-        try(c_char('_').map(|c: char| c.to_string())),
-        try(unicode::char_literal()),
+        attempt(unicode::id_start().map(|c: char| c.to_string())),
+        attempt(c_char('$').map(|c: char| c.to_string())),
+        attempt(c_char('_').map(|c: char| c.to_string())),
+        attempt(unicode::char_literal()),
     )).map(|s: String| s)
 }
 
@@ -729,8 +729,8 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
-        try(ident_start()),
-        try(raw_ident_part().map(|c: char| c.to_string())),
+        attempt(ident_start()),
+        attempt(raw_ident_part().map(|c: char| c.to_string())),
     ))
 }
 

--- a/tests/ecma262/main.rs
+++ b/tests/ecma262/main.rs
@@ -1,6 +1,8 @@
 #![cfg(test)]
 extern crate pretty_env_logger;
 extern crate ress;
+#[macro_use]
+extern crate log;
 
 use std::{fs::read_to_string, path::Path, process::Command};
 
@@ -31,14 +33,18 @@ fn es2015_module() {
 }
 
 fn run_test(js: &str) {
-    for item in Scanner::new(js) {
+    let mut s = Scanner::new(js);
+    let mut i = 0;
+    while let Some(item) = s.next() {
+        debug!("{}, {:?}", i, item.token);
         match item.token {
             Token::Comment(c) => match c.kind {
-                CommentKind::Single => println!("----------\n{}\n----------", c.content),
+                CommentKind::Single => debug!("----------\n{}\n----------", c.content),
                 _ => (),
             },
             _ => (),
         }
+        i += 1;
     }
 }
 


### PR DESCRIPTION
* combine 2018 edition changes
* fix bug in debug print that was overflowing subtraction
* fix bug in template string parsing
  * This significantly simplified the process of parsing template strings
* fix bug in `Token::is_template_*` methods
  * This now reports `NoSub` templates as both `TemplateHead` and `TemplateTail`
