### PR TITLE
Implement Stage 3 hashbang proposal

### DIFF
--- a/examples/count_tokens.rs
+++ b/examples/count_tokens.rs
@@ -49,6 +49,7 @@ fn token_type_str(tok: &Token<&str>) -> &'static str {
         Token::RegEx(_) => "regex",
         Token::Template(_) => "template",
         Token::Comment(_) => "comment",
+        Token::HashbangComment(_) => "hashbang",
         Token::EoF => "eof",
     }
 }
@@ -65,6 +66,7 @@ fn get_initial_counts() -> HashMap<&'static str, usize> {
     counts.insert("punct", 0);
     counts.insert("comment", 0);
     counts.insert("null", 0);
+    counts.insert("hashbang", 0);
     counts.insert("eof", 0);
     counts
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,6 +338,9 @@ impl<'b> Scanner<'b> {
                         }
                     }
                 }
+                RawToken::HashbangComment => {
+                    Token::HashbangComment(Comment::new_single_line(&s[2..]))
+                },
                 RawToken::EoF => {
                     self.eof = true;
                     Token::EoF
@@ -644,13 +647,18 @@ mod test {
     use super::*;
     #[test]
     fn tokenizer() {
-        let js = "
+        let js = "#!/usr/bin/env node
 'use strict';
 function thing() {
     let x = 0;
     console.log('stuff');
 }";
         let expectation = vec![
+            Token::HashbangComment(Comment {
+                kind: tokens::CommentKind::Single,
+                content: "/usr/bin/env node",
+                tail_content: None,
+            }),
             Token::String(StringLit::Single("use strict")),
             Token::Punct(Punct::SemiColon),
             Token::Keyword(Keyword::Function),

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -967,6 +967,24 @@ mod test {
         }
         assert_eq!(&b[item.start..item.end], "#!/usr/bin/env node");
 
+        let b = "#!";
+        let mut t = Tokenizer::new(b);
+        let item = t.next().unwrap();
+        match item.ty {
+            RawToken::HashbangComment => (),
+            _ => panic!("expected hashbang comment, found {:?}", item.ty),
+        }
+        assert_eq!(&b[item.start..item.end], "#!");
+
+        let b = "#!\nlol";
+        let mut t = Tokenizer::new(b);
+        let item = t.next().unwrap();
+        match item.ty {
+            RawToken::HashbangComment => (),
+            _ => panic!("expected hashbang comment, found {:?}", item.ty),
+        }
+        assert_eq!(&b[item.start..item.end], "#!");
+
         let b = "#!/usr/bin/env node\nprocess.exit(1)";
         let mut t = Tokenizer::new(b);
         let item = t.next().unwrap();

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -8,6 +8,7 @@ use crate::error::RawError;
 use unicode::{is_id_continue, is_id_start};
 pub(crate) type Res<T> = Result<T, RawError>;
 
+#[derive(Debug)]
 pub struct RawItem {
     pub ty: tokens::RawToken,
     pub start: usize,
@@ -356,7 +357,7 @@ impl<'a> Tokenizer<'a> {
             ']' => self.gen_punct(Punct::CloseBracket),
             ':' => self.gen_punct(Punct::Colon),
             '?' => self.gen_punct(Punct::QuestionMark),
-            '#' => self.gen_punct(Punct::Hash),
+            '#' => self.hash(),
             '~' => self.gen_punct(Punct::Tilde),
             '{' => self.open_curly(OpenCurlyKind::Block, Punct::OpenBrace),
             '}' => self.close_curly(Punct::CloseBrace),
@@ -559,6 +560,19 @@ impl<'a> Tokenizer<'a> {
             self.gen_punct(Punct::CaretEqual)
         } else {
             self.gen_punct(Punct::Caret)
+        }
+    }
+    fn hash(&mut self) -> Res<RawItem> {
+        // hashbang comment can only appear at the start
+        if self.current_start == 0 && self.stream.next_char() == Some('!') {
+            while !self.at_new_line() {
+                if self.stream.next_char().is_none() {
+                    break;
+                }
+            }
+            self.gen_token(RawToken::HashbangComment)
+        } else {
+            self.gen_punct(Punct::Hash)
         }
     }
     fn number(&mut self, start: char) -> Res<RawItem> {
@@ -940,6 +954,36 @@ mod test {
             let item = t.next().unwrap();
             assert!(item.ty.is_punct());
             assert!(t.stream.at_end());
+        }
+    }
+    #[test]
+    fn tokenizer_hashbang() {
+        let b = "#!/usr/bin/env node";
+        let mut t = Tokenizer::new(b);
+        let item = t.next().unwrap();
+        match item.ty {
+            RawToken::HashbangComment => (),
+            _ => panic!("expected hashbang comment, found {:?}", item.ty),
+        }
+        assert_eq!(&b[item.start..item.end], "#!/usr/bin/env node");
+
+        let b = "#!/usr/bin/env node\nprocess.exit(1)";
+        let mut t = Tokenizer::new(b);
+        let item = t.next().unwrap();
+        match item.ty {
+            RawToken::HashbangComment => (),
+            _ => panic!("expected hashbang comment, found {:?}", item.ty),
+        }
+        assert_eq!(&b[item.start..item.end], "#!/usr/bin/env node");
+
+        // should not parse #! in as hashbang unless it's at the start of the text
+        let b = "\n#!/usr/bin/env node";
+        let mut t = Tokenizer::new(b);
+        t.skip_whitespace();
+        let item = t.next().unwrap();
+        match item.ty {
+            RawToken::Punct(Punct::Hash) => (),
+            _ => panic!("expected hash, found {:?}", item.ty),
         }
     }
     #[test]

--- a/src/tokenizer/tokens.rs
+++ b/src/tokenizer/tokens.rs
@@ -54,6 +54,7 @@ pub enum RawToken {
         new_line_count: usize,
         last_len: usize,
     },
+    HashbangComment
 }
 
 impl RawToken {

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -45,6 +45,12 @@ pub enum Token<T> {
     /// */
     /// ```
     Comment(Comment<T>),
+    /// A hashbang comment, the associated value contains the value.
+    /// ```js
+    /// #!/usr/bin/env node
+    /// process.exit(1)
+    /// ```
+    HashbangComment(Comment<T>),
 }
 
 /// Extension methods for
@@ -131,6 +137,7 @@ impl<'a> ToString for Token<&'a str> {
         match self {
             Token::Boolean(ref b) => b.to_string(),
             Token::Comment(ref c) => c.to_string(),
+            Token::HashbangComment(ref c) => c.to_string(),
             Token::EoF => String::new(),
             Token::Ident(ref i) => i.to_string(),
             Token::Keyword(ref k) => k.to_string(),


### PR DESCRIPTION
If the source text starts with #!, the line is read as a single-line
comment ([spec](http://tc39.es/proposal-hashbang/out.html#sec-updated-syntax)).

In any other place, # is still read as a `Punct::Hash`.

I didn't see the details in #33 before working on this! My approach differs a bit, in that it doesn't add a new Comment type, but reuses the single-line comment type. I did it that way because the spec also appears to reuse the SingleLineCommentChars production. It adds a new token type HashbangComment, which users of the library would have to deal with. That can only ever have a single-line Comment, so it might be a bit annoying to always have to `match` on it. We could use a simple String instead…
Since the hashbang can only be at the very start, before even any whitespace, I think checking `current_start == 0` works to check that it's a valid position for a hashbang comment, but I might be missing something.

Closes #33